### PR TITLE
Switch preload script to ES modules

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -1,4 +1,4 @@
-const { contextBridge,ipcRenderer } = require('electron')
+import { contextBridge, ipcRenderer } from 'electron';
 
 contextBridge.exposeInMainWorld('versions', {
   userlist: () => ipcRenderer.invoke('userlist'),


### PR DESCRIPTION
## Summary
- refactor preload script to use ES module syntax
- preload remains loaded via main.js and ESM is enabled by the project's `type: module`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6856f54810a0832bb5d2d2efead8a816